### PR TITLE
use `hasha`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,26 +1,15 @@
 'use strict';
-
-var crypto = require('crypto');
-var fs = require('fs');
+var hasha = require('hasha');
+var opts = {algorithm: 'sha1'};
 
 module.exports = function (src, cb) {
 	if (Buffer.isBuffer(src)) {
-		var data = src.toString('utf8');
-		cb(null, crypto.createHash('sha1').update(data).digest('hex'));
-		return;
+		setImmediate(cb, null, hasha(src, opts));
+	} else {
+		hasha.fromFile(src, opts, cb);
 	}
-
-	fs.readFile(String(src), 'utf8', function (err, data) {
-		if (err) {
-			cb(err);
-			return;
-		}
-
-		cb(null, crypto.createHash('sha1').update(data).digest('hex'));
-	});
 };
 
 module.exports.sync = function (src) {
-	var data = Buffer.isBuffer(src) ? src.toString('utf8') : fs.readFileSync(String(src), 'utf8');
-	return crypto.createHash('sha1').update(data).digest('hex');
+	return Buffer.isBuffer(src) ? hasha(src, opts) : hasha.fromFileSync(src, opts);
 };

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "author": {
     "name": "Kevin Mårtensson",
     "email": "kevinmartensson@gmail.com",
-    "url": "https://github.com/kevva"
+    "url": "github.com/kevva"
   },
   "engines": {
     "node": ">=0.10.0"
@@ -21,8 +21,12 @@
   "keywords": [
     "file",
     "hash",
-    "name"
+    "name",
+    "crypto"
   ],
+  "dependencies": {
+    "hasha": "^1.0.0"
+  },
   "devDependencies": {
     "ava": "^0.0.4"
   }

--- a/test/test.js
+++ b/test/test.js
@@ -1,25 +1,28 @@
 'use strict';
-
 var fs = require('fs');
 var path = require('path');
 var test = require('ava');
 var hashFile = require('../');
 
 test('return a hashed file name from a string', function (t) {
+	t.plan(2);
+
 	var src = path.join(__dirname, 'fixtures/test.jpg');
 
 	hashFile(src, function (err, hash) {
 		t.assert(!err, err);
-		t.assert(hash === 'ac8b2c4b75b2d36988c62b919a857f1baacfcd4c', hash);
+		t.assert(hash === '1bc522c89a9cd36ee274b2e0b2c8bc91d2760c46', hash);
 	});
 });
 
 test('return a hashed file name from a Buffer', function (t) {
+	t.plan(2);
+
 	var src = new Buffer(fs.readFileSync(path.join(__dirname, 'fixtures/test.jpg')));
 
 	hashFile(src, function (err, hash) {
 		t.assert(!err, err);
-		t.assert(hash === 'ac8b2c4b75b2d36988c62b919a857f1baacfcd4c', hash);
+		t.assert(hash === '1bc522c89a9cd36ee274b2e0b2c8bc91d2760c46', hash);
 	});
 });
 
@@ -27,7 +30,7 @@ test('synchronously return a hashed file name from a string', function (t) {
 	var src = path.join(__dirname, 'fixtures/test.jpg');
 	var hash = hashFile.sync(src);
 
-	t.assert(hash === 'ac8b2c4b75b2d36988c62b919a857f1baacfcd4c', hash);
+	t.assert(hash === '1bc522c89a9cd36ee274b2e0b2c8bc91d2760c46', hash);
 	t.end();
 });
 
@@ -35,6 +38,6 @@ test('synchronously return a hashed file name from a Buffer', function (t) {
 	var src = new Buffer(fs.readFileSync(path.join(__dirname, 'fixtures/test.jpg')));
 	var hash = hashFile.sync(src);
 
-	t.assert(hash === 'ac8b2c4b75b2d36988c62b919a857f1baacfcd4c', hash);
+	t.assert(hash === '1bc522c89a9cd36ee274b2e0b2c8bc91d2760c46', hash);
 	t.end();
 });


### PR DESCRIPTION
https://github.com/sindresorhus/hasha

In addition to less code this fixes 3 things:
- In the main function when a buffer was passed the callback was called immediately. This should have the same behaviour as when a path is passed and be async. (Never mix sync and async).
- You should not force the buffer to string, as buffers are more efficient to hash.
- Uses a streaming hasher for the async file reading to make it a lot faster: https://github.com/sindresorhus/hasha/blob/76ec22e37f6bce68849bac2b8cbd3d748e463ea3/index.js#L46-L51
